### PR TITLE
added awful library require

### DIFF
--- a/widget/imap.lua
+++ b/widget/imap.lua
@@ -8,6 +8,7 @@
 local helpers  = require("lain.helpers")
 local naughty  = require("naughty")
 local wibox    = require("wibox")
+local awful    = require("awful")
 local string   = { format = string.format,
                    gsub   = string.gsub }
 local type     = type


### PR DESCRIPTION
setting the 'followtag' option of the imap widget to true was causing the update function to fail. The function was calling awful.screen.focused(), which failed because the awful library wasn't included.