### PR TITLE
Updates widget

### DIFF
--- a/widget/contrib/updates.lua
+++ b/widget/contrib/updates.lua
@@ -1,0 +1,84 @@
+--[[
+
+     Licensed under GNU General Public License v2
+      * (c) 2017, Alphonse Mariyagnanaseelan
+
+--]]
+
+local helpers       = require("lain.helpers")
+local awful         = require("awful")
+local shell         = require("awful.util").shell
+local wibox         = require("wibox")
+local naughty       = require("naughty")
+local lines, floor  = io.lines, math.floor
+local string        = { format = string.format,
+                        gsub   = string.gsub,
+                        len    = string.len}
+
+-- Available updates
+-- lain.widget.contrib.updates
+
+local function factory(args)
+    local updates          = { widget = wibox.widget.textbox() }
+    local args            = args or {}
+    local timeout         = args.timeout or 900
+
+    local notify          = args.notify or false
+    local notify_title    = args.notify_title or "Updates"
+    local notify_timeout  = args.notify_timeout or 15
+
+    local settings        = args.settings or function() end
+    local package_manager = args.package_manager
+    local command         = args.command or ""
+
+    local commands = {
+        pacman        = "checkupdates | sed 's/->/→/' | column -t",
+        pacaur        = "pacaur -k --color never | sed 's/:: [a-zA-Z0-9]\\+ //' | sed 's/->/→/' | column -t",
+        pacman_pacaur = "( checkupdates & pacaur -k --color never | sed 's/:: [a-zA-Z0-9]\\+ //' ) | sed 's/->/→/' | sort | column -t",
+        dnf           = "dnf check-update --quiet",
+        apt           = "apt-show-versions -u"
+    }
+
+    local update_count = 0
+
+    function updates.update(notify)
+        helpers.async({ shell, "-c", commands[package_manager] or command }, function(update_text)
+            available  = tonumber((update_text:gsub('[^\n]', '')):len())
+            widget = updates.widget
+
+            if available > update_count and notify then
+                updates.show_notification(update_text)
+            end
+            update_count = available
+            settings()
+        end)
+    end
+
+    function updates.automatic_update()
+        -- Notify if set and update_count has increased
+        updates.update(notify)
+    end
+
+    function updates.manual_update()
+        -- Allways show notification
+        update_count = -1
+        updates.update(true)
+    end
+
+    function updates.show_notification(update_text)
+        if not update_text or update_text == "" then
+            update_text = "None."
+        end
+        naughty.notify({
+            title = notify_title,
+            text = string.gsub(update_text, '[\n%s]*$', ''),
+            timeout = notify_timeout
+        })
+    end
+
+    helpers.newtimer("updates", timeout, updates.automatic_update)
+
+    return updates
+end
+
+return factory


### PR DESCRIPTION
A new widget that will show the number of available updates. Command to check updates can be configured or chosen from the provided ones. Will show a notification when the update count has increased (can be deactivated). This widget may be useful for people who use rolling release distributions, perhaps less useful for point release distribution users.

With the provided options you could for example set up two separate widgets, for `pacman` and `pacaur`, or a combined one.

![Updates widget](https://i.imgur.com/ltbet8c.png)
An example; note the pacman icon.

I tried to keep this as general as possible, so it is possible to show outdated `pip` packages with `pip list --outdated --format=legacy` for example. You could use it for anything unrelated too, as what it basically does is line-counting and notifying when the line count changes.

Usage may look like this:

```lua
local pacman_widget = lain.widget.contrib.updates({
    package_manager = "pacman",
    notify = true,
    settings = function()
        widget:set_markup(markup.fontfg(normal_font, normal_color, available))
    end
})
```