### PR TITLE
Extra functionality in net.lua, full battery notification, a new widget for monitoring external drives

### DIFF
--- a/widget/bat.lua
+++ b/widget/bat.lua
@@ -47,6 +47,14 @@ local function factory(args)
         bg      = "#CDCDCD"
     }
 
+    bat_notification_charged_preset = {
+        title = "Battery full",
+        text  = "You can unplug the cable",
+        timeout = 15,
+        fg      = "#202020",
+        bg      = "#CDCDCD"
+    }
+
     bat_now = {
         status    = "N/A",
         ac_status = "N/A",
@@ -156,16 +164,23 @@ local function factory(args)
         widget = bat.widget
         settings()
 
-        -- notifications for critical and low levels
-        if notify == "on" and bat_now.status == "Discharging" then
-            if tonumber(bat_now.perc) <= n_perc[1] then
+        -- notifications for critical, low, and full levels
+        if notify == "on" then
+            if bat_now.status == "Discharging" then
+                if tonumber(bat_now.perc) <= n_perc[1] then
+                    bat.id = naughty.notify({
+                        preset = bat_notification_critical_preset,
+			            replaces_id = bat.id
+                    }).id
+                elseif tonumber(bat_now.perc) <= n_perc[2] then
+                    bat.id = naughty.notify({
+                        preset = bat_notification_low_preset,
+                        replaces_id = bat.id
+                    }).id
+                end
+            elseif bat_now.status == "Full" then
                 bat.id = naughty.notify({
-                    preset = bat_notification_critical_preset,
-                    replaces_id = bat.id
-                }).id
-            elseif tonumber(bat_now.perc) <= n_perc[2] then
-                bat.id = naughty.notify({
-                    preset = bat_notification_low_preset,
+                    preset = bat_notification_charged_preset,
                     replaces_id = bat.id
                 }).id
             end

--- a/widget/contrib/extdrive.lua
+++ b/widget/contrib/extdrive.lua
@@ -1,0 +1,63 @@
+--[[
+
+    Licensed under GNU General Public License v2
+    * (c) 2018, Bill Ayala
+
+--]]
+
+local async    = require("lain.helpers").async
+local newtimer = require("lain.helpers").newtimer
+local textbox  = require("wibox.widget").textbox
+local os       = { execute = os.execute }
+
+-- External drive presence indicator
+-- lain.widget.contrib.extdrive
+
+local function factory(args)
+    local extdrive = { widget = textbox() }
+    local args     = args or {}
+    local timeout  = args.timeout or 5
+    local drives   = args.drives or (args.drive and {args.drive}) or {"/dev/sdb1"}
+    local settings = args.settings or function() end
+
+    extdrive_now = {}
+    extdrive_now.n_present    = {}
+    extdrive_now.n_mounted    = {}
+    extdrive_now.n_mountpoint = {}
+
+    for i = 1, #drives do
+        extdrive_now.n_present[i]    = false
+        extdrive_now.n_mounted[i]    = false
+        extdrive_now.n_mountpoint[i] = "N/A"
+    end
+
+    function extdrive.update()
+        for i, drive in ipairs(drives) do
+            async("findmnt -n -o TARGET " .. drive, function(mountpoint, exit_code)
+                if exit_code == 0 then
+                    extdrive_now.n_present[i]    = true
+                    extdrive_now.n_mounted[i]    = true
+                    extdrive_now.n_mountpoint[i] = mountpoint
+                else
+                    if os.execute("ls " .. drive) == 0 then
+                        extdrive_now.n_present[i] = true
+                    else
+                        extdrive_now.n_present[i] = false
+                    end
+
+                    extdrive_now.n_mounted[i]    = false
+                    extdrive_now.n_mountpoint[i] = "N/A"
+                end
+            end)
+	    end
+
+        widget = extdrive.widget
+        settings()
+    end
+
+    newtimer("drives", timeout, extdrive.update)
+
+    return extdrive
+end
+
+return factory


### PR DESCRIPTION
The new helper function helpers.line_callback gets used in net.lua so that all network interfaces except loopback ones get added to net.iface, even if they don't have an active connection. This makes the widget more flexible since it can now detect changes in the interface after the widget's been loaded. This is useful if for example the widget's loaded while the ethernet's unconnected and then later the user switches to ethernet.

helpers.async and helpers.async_with_shell can now return the process' exit code, so widgets can use it in if statements. extdrive.lua makes use of that