### PR TITLE
fix for quake buginess

### DIFF
--- a/util/quake.lua
+++ b/util/quake.lua
@@ -158,7 +158,10 @@ function quake:toggle()
      if self.followtag then self.screen = awful.screen.focused() end
      local current_tag = self.screen.selected_tag
      if current_tag and self.last_tag ~= current_tag and self.visible then
-         self:display():move_to_tag(current_tag)
+         local c=self:display()
+         if c then
+            c:move_to_tag(current_tag)
+        end
      else
          self.visible = not self.visible
          self:display()


### PR DESCRIPTION
sometimes, `self:display` wouldn't return a client object, so calling `move_to_tag` on its return value directly would throw errors. this fixes that by inserting a simple `if` statement to check the return value.