### PR TITLE
add screen and tag arguments to useless_gaps_resize function

### DIFF
--- a/util/init.lua
+++ b/util/init.lua
@@ -158,9 +158,10 @@ end
 -- }}}
 
 -- On the fly useless gaps change
-function util.useless_gaps_resize(thatmuch)
-    local scr = awful.screen.focused()
-    scr.selected_tag.gap = scr.selected_tag.gap + tonumber(thatmuch)
+function util.useless_gaps_resize(thatmuch, s, t)
+    local scr = s or awful.screen.focused()
+    local tag = t or scr.selected_tag
+    tag.gap = tag.gap + tonumber(thatmuch)
     awful.layout.arrange(scr)
 end
 


### PR DESCRIPTION
Rationale: allow to resize gaps for multiple tags at once.
For example, resize all of them:
```lua
for s in screen do
    for _, t in ipairs(s.tags) do
        lain.util.useless_gaps_resize(-1, nil, t)
    end
end
```