### PR TITLE
imap change request

### DIFF
--- a/widget/imap.lua
+++ b/widget/imap.lua
@@ -93,6 +93,7 @@ local function factory(args)
 
     end
 
+    imap.update = update
     imap.timer = helpers.newtimer(mail, timeout, update, true, true)
 
     return imap

--- a/widget/imap.lua
+++ b/widget/imap.lua
@@ -40,11 +40,24 @@ local function factory(args)
         if type(password) == "string" or type(password) == "table" then
             helpers.async(password, function(f) password = f:gsub("\n", "") end)
         elseif type(password) == "function" then
-            local p = password()
+            imap.functimer = helpers.newtimer(mail .. "-pass", timeout/2, function() end, true, true)
+            helpers.newtimer(
+                mail .. "-pass",
+                timeout/2,
+                function()
+                    local pass, try_again = password()
+                    if not try_again then
+                        imap.functimer:stop()
+                        password = pass or ""
+                    end
+                end,
+                false,
+                true)
         end
     end
 
     function update()
+        if type(password) ~= "string" then return end
         mail_notification_preset = {
             icon     = helpers.icons_dir .. "mail.png",
             position = "top_left"


### PR DESCRIPTION
This request aims to solve two issues:
1. Password special characters are not allowed
To solve this, simply enclose `password` into single quotes `'` instead of double quotes `"`
1. Widget doesn't work with [gmail](https://mail.google.com/mail) and [yandex mail](https://mail.yandex.com/). This issue has been reported  [before](https://github.com/lcpz/lain/issues/74#issuecomment-75032395).

I believe that the reason for this issue is the request `SEARCH (UNSEEN)`. Seems that response syntax  vary from implementation to implementation. I propose to use the request `STATUS INBOX (MESSAGES RECENT UNSEEN)`. Not only it works with both [gmail](https://mail.google.com/mail) and [yandex mail](https://mail.yandex.com/), it allows to get additional info in one request.

Request:
`curl -v --connect-timeout 3 -fsm 3 --url imaps://imap.gmail.com:993/INBOX -u $mail:$pass -X 'STATUS INBOX (MESSAGES RECENT UNSEEN)' -k`
Response:
`* STATUS "INBOX" (MESSAGES 7 RECENT 0 UNSEEN 3)`