### PR TITLE
fix imap notifications

### DIFF
--- a/widget/imap.lua
+++ b/widget/imap.lua
@@ -68,7 +68,6 @@ local function factory(args)
 
             for s, d in f:gmatch("(%w+)%s+(%d+)") do imap_now[s] = tonumber(d) end
             mailcount = imap_now["UNSEEN"] -- backwards compatibility
-            helpers.set_map(mail, mailcount)
             widget = imap.widget
 
             settings()
@@ -80,6 +79,7 @@ local function factory(args)
                     text   = string.format("%s has <b>%d</b> new message%s", mail, mailcount, mailcount == 1 and "" or "s")
                 }
             end
+            helpers.set_map(mail, mailcount)
         end)
 
     end


### PR DESCRIPTION
**Problem:** imap notifications never show
**Cause:** notification condition `mailcount > helpers.get_map(mail)` is never satisfied because `helpers.set_map(mail, mailcount)` is called right before `if` statement
**Solution:** move `helpers.set_map` after the notification function
