### PR TITLE
util/menu_iterator: retro compatibility with lua 5.1

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -12,7 +12,8 @@ local io         = { lines = io.lines,
                      open  = io.open }
 local pairs      = pairs
 local rawget     = rawget
-local table      = { sort  = table.sort }
+local table      = { sort  = table.sort, unpack = table.unpack }
+local unpack     = unpack or table.unpack -- lua 5.1 retro-compatibility
 
 -- Lain helper functions for internal use
 -- lain.helpers

--- a/util/menu_iterator.lua
+++ b/util/menu_iterator.lua
@@ -11,12 +11,13 @@
 -- lain.util.menu_iterator
 
 local naughty = require("naughty")
+local helpers = require("lain.helpers")
 local util    = require("lain.util")
 local atable  = require("awful.util").table
 local assert  = assert
 local pairs   = pairs
 local tconcat = table.concat
-local unpack  = unpack
+local unpack = unpack or table.unpack -- lua 5.1 retro-compatibility
 
 local state = { cid = nil }
 


### PR DESCRIPTION
Since lua 5.2, `unpack` is no longer part of the global scope, but is now in `table`. This fix takes that into account in a retro-compatible fashion.