### PR TITLE
Weather status icon fix

### DIFF
--- a/widget/weather.lua
+++ b/widget/weather.lua
@@ -117,20 +117,7 @@ local function factory(args)
                 local sunrise = tonumber(weather_now["sys"]["sunrise"])
                 local sunset  = tonumber(weather_now["sys"]["sunset"])
                 local icon    = weather_now["weather"][1]["icon"]
-                local loc_now = os.time() -- local time
-                local loc_m   = os.time { year = os.date("%Y"), month = os.date("%m"), day = os.date("%d"), hour = 0 } -- local time from midnight
-                local loc_d   = os.date("*t",  loc_now) -- table YMDHMS for current local time (for TZ calculation)
-                local utc_d   = os.date("!*t", loc_now) -- table YMDHMS for current UTC time
-                local utc_now = os.time(utc_d) -- UTC time now
-                local offdt   = (loc_d.isdst and 1 or 0) * 3600 + 100 * (loc_d.min  - utc_d.min) / 60 -- DST offset
-                local offset  = os.difftime(loc_now, utc_now) + (loc_d.isdst and 1 or 0) * 3600 + 100 * (loc_d.min  - utc_d.min) / 60 -- TZ offset (including DST)
-                local offday  = (offset < 0 and -86400) or 86400 -- 24 hour correction value (+86400 or -86400)
-
-                -- if current UTC time is earlier then local midnight -> positive offset (negative otherwise)
-                if offset * (loc_m - utc_now + offdt) > 0 then
-                    sunrise = sunrise + offday -- Shift sunset and sunrise times by 24 hours
-                    sunset  = sunset  + offday
-                end
+                local loc_now = os.time()
 
                 if sunrise <= loc_now and loc_now <= sunset then
                     icon = string.gsub(icon, "n", "d")


### PR DESCRIPTION
In regarding to #428.
It looks like OpenWeatherMap have fixed most of issues in their API. Now they return sunrise and sunset times properly for current time zone, however the status icon is still wrong:
- transition N->D appears at 0:00 UTC (must be at local sunrise time)
- whereas D->N appears at local sunset time

So we still need to check if we're in or out from sunrise/sunset times, but no need to perform all other manipulations with dates and times.