### PR TITLE
pulsebar: use devicetype and device instead of sink (null var)

### DIFF
--- a/widget/pulsebar.lua
+++ b/widget/pulsebar.lua
@@ -154,7 +154,7 @@ local function factory(args)
         end)
     end
 
-    helpers.newtimer(string.format("pulsebar-%s", pulsebar.sink), timeout, pulsebar.update)
+    helpers.newtimer(string.format("pulsebar-%s-%s", pulsebar.devicetype, pulsebar.device), timeout, pulsebar.update)
 
     return pulsebar
 end


### PR DESCRIPTION
pretty trivial fix