### PR TITLE
alsabar: Calculate tot based on notification width

### DIFF
--- a/widget/alsabar.lua
+++ b/widget/alsabar.lua
@@ -118,13 +118,13 @@ local function factory(args)
             -- tot is the maximum number of ticks to display in the notification
             -- fallback: default horizontal wibox height
             local wib, tot = awful.screen.focused().mywibox, 20
-	          local notwidth = beautiful.notification_width
+            local notwidth = beautiful.notification_width
             --calculate tot based on notification width and icon presense
-	          if preset.icon == nil then
-	          	  tot = notwidth / 10
-	          else
-	          	  tot = notwidth / 12
-	          end
+            if preset.icon == nil then
+              	  tot = notwidth / 10
+	    else
+	      	  tot = notwidth / 12
+	    end
 
             int = math.modf((alsabar._current_level / 100) * tot)
             preset.text = string.format("[%s%s]", string.rep("|", int),

--- a/widget/alsabar.lua
+++ b/widget/alsabar.lua
@@ -10,6 +10,7 @@ local helpers  = require("lain.helpers")
 local awful    = require("awful")
 local naughty  = require("naughty")
 local wibox    = require("wibox")
+local beautiful    = require("beautiful")
 local math     = math
 local string   = string
 local type     = type
@@ -117,16 +118,13 @@ local function factory(args)
             -- tot is the maximum number of ticks to display in the notification
             -- fallback: default horizontal wibox height
             local wib, tot = awful.screen.focused().mywibox, 20
-
-            -- if we can grab mywibox, tot is defined as its height if
-            -- horizontal, or width otherwise
-            if wib then
-                if wib.position == "left" or wib.position == "right" then
-                    tot = wib.width
-                else
-                    tot = wib.height
-                end
-            end
+	          local notwidth = beautiful.notification_width
+            --calculate tot based on notification width and icon presense
+	          if preset.icon == nil then
+	          	  tot = notwidth / 10
+	          else
+	          	  tot = notwidth / 12
+	          end
 
             int = math.modf((alsabar._current_level / 100) * tot)
             preset.text = string.format("[%s%s]", string.rep("|", int),

--- a/widget/alsabar.lua
+++ b/widget/alsabar.lua
@@ -122,9 +122,9 @@ local function factory(args)
             --calculate tot based on notification width and icon presense
             if preset.icon == nil then
               	  tot = notwidth / 10
-	    else
-	      	  tot = notwidth / 12
-	    end
+            else
+                  tot = notwidth / 12
+            end
 
             int = math.modf((alsabar._current_level / 100) * tot)
             preset.text = string.format("[%s%s]", string.rep("|", int),


### PR DESCRIPTION
Currently tot is calculated on wibox width/height for some reason. Here is a proposal to do it based on notification width not ideal but still working much better as the old way. Another approach could be to add tot to the notification_preset table and let users to choose it manually.