### PR TITLE
fix fs widget notification alignment

### DIFF
--- a/widget/fs.lua
+++ b/widget/fs.lua
@@ -121,7 +121,7 @@ local function factory(args)
             end
         end
 
-        local fmt = "%-" .. tostring(pathlen) .. "s %4s\t%6s\t%6s\t\n"
+        local fmt = "%-" .. tostring(pathlen) .. "s %4s\t%6s\t%6s\n"
         local notifytable = { [1] = string.format(fmt, "path", "used", "free", "size") }
         fmt = "\n%-" .. tostring(pathlen) .. "s %3s%%\t%6.2f\t%6.2f %s"
         for _, path in ipairs(notifypaths) do

--- a/widget/fs.lua
+++ b/widget/fs.lua
@@ -69,11 +69,10 @@ local function factory(args)
     end
 
     function fs.update()
-        local notifytable = { [1] = string.format("%-10s %4s\t%6s\t%6s\t\n", "path", "used", "free", "size") }
         local pathlen = 10
-        local maxpathidx = 1
         fs_now = {}
 
+        local notifypaths = {}
         for _, mount in ipairs(Gio.unix_mounts_get()) do
             local path = Gio.unix_mount_get_mount_path(mount)
             local root = Gio.File.new_for_path(path)
@@ -96,13 +95,10 @@ local function factory(args)
                     }
 
                     if fs_now[path].percentage > 0 then -- don't notify unused file systems
-                        notifytable[#notifytable+1] = string.format("\n%-10s %3s%%\t%6.2f\t%6.2f\t%s", path,
-                        math.floor(fs_now[path].percentage), fs_now[path].free, fs_now[path].size,
-                        fs_now[path].units)
+                        notifypaths[#notifypaths+1] = path
 
                         if #path > pathlen then
                             pathlen = #path
-                            maxpathidx = #notifytable
                         end
                     end
                 end
@@ -125,14 +121,11 @@ local function factory(args)
             end
         end
 
-        if pathlen > 10 then -- if are there paths longer than 10 chars, reformat first column accordingly
-            local pathspaces
-            for i = 1, #notifytable do
-                pathspaces = notifytable[i]:match("[ ]+")
-                if i ~= maxpathidx and pathspaces then
-                    notifytable[i] = notifytable[i]:gsub(pathspaces, pathspaces .. string.rep(" ", pathlen - 10))
-                end
-            end
+        local fmt = "%-" .. tostring(pathlen) .. "s %4s\t%6s\t%6s\t\n"
+        local notifytable = { [1] = string.format(fmt, "path", "used", "free", "size") }
+        fmt = "\n%-" .. tostring(pathlen) .. "s %3s%%\t%6.2f\t%6.2f %s"
+        for _, path in ipairs(notifypaths) do
+            notifytable[#notifytable+1] = string.format(fmt, path, fs_now[path].percentage, fs_now[path].free, fs_now[path].size, fs_now[path].units)
         end
 
         fs.notification_preset.text = tconcat(notifytable)

--- a/widget/fs.lua
+++ b/widget/fs.lua
@@ -89,9 +89,9 @@ local function factory(args)
                     fs_now[path] = {
                         units      = fs.units[units],
                         percentage = math.floor(100 * used / size), -- used percentage
-                        size       = size / math.pow(1024, math.floor(units)),
-                        used       = used / math.pow(1024, math.floor(units)),
-                        free       = free / math.pow(1024, math.floor(units))
+                        size       = size / math.pow(1024, units),
+                        used       = used / math.pow(1024, units),
+                        free       = free / math.pow(1024, units)
                     }
 
                     if fs_now[path].percentage > 0 then -- don't notify unused file systems


### PR DESCRIPTION
Fixes alignment by computing max path length first and then formatting each partition. Also changes units from `"\t%s"` to `" %s"`.

Before:
![before](https://user-images.githubusercontent.com/468514/82731708-bdd4dd80-9cd6-11ea-9c2b-b35046b560ea.png)

After:
![after](https://user-images.githubusercontent.com/468514/82731714-c62d1880-9cd6-11ea-837a-90d31894911f.png)
