### PR TITLE
Fix notification text for calendar widget

### DIFF
--- a/widget/cal.lua
+++ b/widget/cal.lua
@@ -126,14 +126,14 @@ local function factory(args)
     end
 
     function cal.show(seconds, month, year, scr)
-        cal.notification_preset.text = tconcat(cal.build(month, year))
+        local text = tconcat(cal.build(month, year))
 
         if cal.three then
             local current_month, current_year = cal.month, cal.year
             local prev_month, prev_year = cal.getdate(cal.month, cal.year, -1)
             local next_month, next_year = cal.getdate(cal.month, cal.year,  1)
-            cal.notification_preset.text = string.format("%s\n\n%s\n\n%s",
-            tconcat(cal.build(prev_month, prev_year)), cal.notification_preset.text,
+            text = string.format("%s\n\n%s\n\n%s",
+            tconcat(cal.build(prev_month, prev_year)), text,
             tconcat(cal.build(next_month, next_year)))
             cal.month, cal.year = current_month, current_year
         end
@@ -143,7 +143,8 @@ local function factory(args)
             preset  = cal.notification_preset,
             screen  = cal.followtag and awful.screen.focused() or scr or 1,
             icon    = cal.icon,
-            timeout = type(seconds) == "number" and seconds or cal.notification_preset.timeout or 5
+            timeout = type(seconds) == "number" and seconds or cal.notification_preset.timeout or 5,
+            text    = text
         }
     end
 


### PR DESCRIPTION
Since the `notification_preset` isn't apparently working for the notification text, just set the field `text` on it's own.