### PR TITLE
Fix the nil values in net

### DIFF
--- a/widget/net.lua
+++ b/widget/net.lua
@@ -68,13 +68,19 @@ local function factory(args)
             dev_now.last_t   = now_t
             dev_now.last_r   = now_r
 
-            if wifi_state == "on" and helpers.first_line(string.format("/sys/class/net/%s/uevent", dev)) == "DEVTYPE=wlan" and string.match(dev_now.carrier, "1") then
+            if wifi_state == "on" and helpers.first_line(string.format("/sys/class/net/%s/uevent", dev)) == "DEVTYPE=wlan" then
                 dev_now.wifi   = true
-                dev_now.signal = tonumber(string.match(helpers.lines_from("/proc/net/wireless")[3], "(%-%d+%.)")) or nil
+								if string.match(dev_now.carrier, "1") then
+	              		dev_now.signal = tonumber(string.match(helpers.lines_from("/proc/net/wireless")[3], "(%-%d+%.)")) or nil
+								end
+						else
+                dev_now.wifi   = false
             end
 
-            if eth_state == "on" and helpers.first_line(string.format("/sys/class/net/%s/uevent", dev)) ~= "DEVTYPE=wlan" and string.match(dev_now.carrier, "1") then
+            if eth_state == "on" and helpers.first_line(string.format("/sys/class/net/%s/uevent", dev)) ~= "DEVTYPE=wlan" then
                 dev_now.ethernet = true
+						else
+                dev_now.ethernet = false
             end
 
             net.devices[dev] = dev_now


### PR DESCRIPTION
Fixes #469 

This makes sure that Ethernet and WiFi interfaces can be detected when a connection isn't fully there.