### PR TITLE
Fix various luacheck warnings

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -109,7 +109,7 @@ end
 -- @return cmd PID
 function helpers.async(cmd, callback)
     return spawn.easy_async(cmd,
-    function (stdout, stderr, reason, exit_code)
+    function (stdout, _, _, exit_code)
         callback(stdout, exit_code)
     end)
 end
@@ -117,7 +117,7 @@ end
 -- like above, but call spawn.easy_async with a shell
 function helpers.async_with_shell(cmd, callback)
     return spawn.easy_async_with_shell(cmd,
-    function (stdout, stderr, reason, exit_code)
+    function (stdout, _, _, exit_code)
         callback(stdout, exit_code)
     end)
 end

--- a/layout/centerwork.lua
+++ b/layout/centerwork.lua
@@ -125,7 +125,7 @@ local function arrange(p, layout)
     end
 end
 
-local function mouse_resize_handler(c, corner, x, y, orientation)
+local function mouse_resize_handler(c, _, _, _, orientation)
     local wa     = c.screen.workarea
     local mwfact = c.screen.selected_tag.master_width_factor
     local g      = c:geometry()
@@ -208,7 +208,7 @@ end
 local function clients_by_position()
     local this = client.focus
     if this then
-        sorted = client.focus.first_tag:clients()
+        local sorted = client.focus.first_tag:clients()
         table.sort(sorted, compare_position)
 
         local idx = 0

--- a/layout/termfair.lua
+++ b/layout/termfair.lua
@@ -240,7 +240,7 @@ local function do_fair(p, orientation)
             for i = 1, (num_x-1) do
                 local height = math.floor(wa.height / num_y[i])
                 local wy = wa.y
-                for j = 0, (num_y[i]-2) do
+                for _ = 0, (num_y[i]-2) do
                     local g = {}
                     g.x = wx
                     g.y = wy

--- a/util/dkjson.lua
+++ b/util/dkjson.lua
@@ -42,8 +42,8 @@ SOFTWARE.
 --]==]
 
 -- global dependencies:
-local pairs, type, tostring, tonumber, getmetatable, setmetatable, rawset =
-      pairs, type, tostring, tonumber, getmetatable, setmetatable, rawset
+local pairs, type, tostring, tonumber, getmetatable, setmetatable =
+      pairs, type, tostring, tonumber, getmetatable, setmetatable
 local error, require, pcall, select = error, require, pcall, select
 local floor, huge = math.floor, math.huge
 local strrep, gsub, strsub, strbyte, strchar, strfind, strlen, strformat =
@@ -246,7 +246,7 @@ local function exception(reason, value, state, buffer, buflen, defaultmessage)
   end
 end
 
-function json.encodeexception(reason, value, state, defaultmessage)
+function json.encodeexception(_, _, _, defaultmessage)
   return quotestring("<" .. defaultmessage .. ">")
 end
 
@@ -321,7 +321,7 @@ encode2 = function (value, indent, level, buffer, buflen, tables, globalorder, s
           local v = value[k]
           if v then
             used[k] = true
-            buflen, msg = addpair (k, v, prev, indent, level, buffer, buflen, tables, globalorder, state)
+            buflen, _ = addpair (k, v, prev, indent, level, buffer, buflen, tables, globalorder, state)
             prev = true -- add a seperator before the next element
           end
         end
@@ -504,7 +504,6 @@ end
 local scanvalue -- forward declaration
 
 local function scantable (what, closechar, str, startpos, nullval, objectmeta, arraymeta)
-  local len = strlen (str)
   local tbl, n = {}, 0
   local pos = startpos + 1
   if what == 'object' then
@@ -626,7 +625,7 @@ function json.use_lpeg ()
   local PlainChar = 1 - S"\"\\\n\r"
   local EscapeSequence = (P"\\" * g.C (S"\"\\/bfnrt" + Err "unsupported escape sequence")) / escapechars
   local HexDigit = R("09", "af", "AF")
-  local function UTF16Surrogate (match, pos, high, low)
+  local function UTF16Surrogate (_, _, high, low)
     high, low = tonumber (high, 16), tonumber (low, 16)
     if 0xD800 <= high and high <= 0xDBff and 0xDC00 <= low and low <= 0xDFFF then
       return true, unichar ((high - 0xD800)  * 0x400 + (low - 0xDC00) + 0x10000)

--- a/util/init.lua
+++ b/util/init.lua
@@ -39,7 +39,7 @@ function util.menu_clients_current_tags(menu, args)
         local t   = cls_tags[i]
         local cls = t:clients()
 
-        for k, c in pairs(cls) do
+        for _, c in pairs(cls) do
             cls_t[#cls_t + 1] = { awful.util.escape(c.name) or "",
                                   function ()
                                       c.minimized = false
@@ -99,7 +99,7 @@ end
 function util.tag_view_nonempty(direction, sc)
    local s = sc or awful.screen.focused()
 
-   for i = 1, #s.tags do
+   for _ = 1, #s.tags do
        awful.tag.viewidx(direction, s)
        if #s.clients > 0 then
            return

--- a/util/menu_iterator.lua
+++ b/util/menu_iterator.lua
@@ -12,7 +12,6 @@
 
 local naughty = require("naughty")
 local helpers = require("lain.helpers")
-local util    = require("lain.util")
 local atable  = require("awful.util").table
 local assert  = assert
 local pairs   = pairs
@@ -42,8 +41,8 @@ end
 -- * timeout: time to wait before confirming the menu selection
 -- * icon:    icon to display in the notification of the chosen label
 local function iterate(menu, timeout, icon)
-    local timeout = timeout or 4 -- default timeout for each menu entry
-    local icon    = icon or nil  -- icon to display on the menu
+    timeout = timeout or 4 -- default timeout for each menu entry
+    icon    = icon or nil  -- icon to display on the menu
 
     -- Build the list of choices
     if not state.index then
@@ -104,7 +103,7 @@ local function menu(args)
 
     local ch_combinations = args.combination == "powerset" and helpers.powerset(choices) or helpers.trivial_partition_set(choices)
 
-    for _,c in pairs(extra_choices) do
+    for _, c in pairs(extra_choices) do
         ch_combinations = atable.join(ch_combinations, {{c[1]}})
     end
 

--- a/util/quake.lua
+++ b/util/quake.lua
@@ -50,7 +50,7 @@ function quake:display()
 
     if not client then
         -- The client does not exist, we spawn it
-        cmd = string.format("%s %s %s", self.app,
+        local cmd = string.format("%s %s %s", self.app,
               string.format(self.argname, self.name), self.extra)
         awful.spawn(cmd, { tag = self.screen.selected_tag })
         return
@@ -89,8 +89,8 @@ function quake:display()
         client.fullscreen = false
         client.hidden = true
         local ctags = client:tags()
-        for i, t in pairs(ctags) do
-            ctags[i] = nil
+        for j, _ in pairs(ctags) do
+            ctags[j] = nil
         end
         client:tags(ctags)
     end

--- a/util/separators.lua
+++ b/util/separators.lua
@@ -21,17 +21,17 @@ function separators.arrow_right(col1, col2)
     widget.col1 = col1
     widget.col2 = col2
 
-    widget.fit = function(m, w, h)
+    widget.fit = function(_, _, _)
         return separators.width, separators.height
     end
 
-    widget.update = function(col1, col2)
+    widget.update = function(_, _)
         widget.col1 = col1
         widget.col2 = col2
         widget:emit_signal("widget::redraw_needed")
     end
 
-    widget.draw = function(mycross, wibox, cr, width, height)
+    widget.draw = function(_, _, cr, width, height)
         if widget.col2 ~= "alpha" then
             cr:set_source_rgb(gears.color.parse_color(widget.col2))
             cr:new_path()
@@ -69,7 +69,7 @@ function separators.arrow_left(col1, col2)
     widget.col1 = col1
     widget.col2 = col2
 
-    widget.fit = function(m, w, h)
+    widget.fit = function(_, _, _)
         return separators.width, separators.height
     end
 
@@ -79,7 +79,7 @@ function separators.arrow_left(col1, col2)
         widget:emit_signal("widget::redraw_needed")
     end
 
-    widget.draw = function(mycross, wibox, cr, width, height)
+    widget.draw = function(_, _, cr, width, height)
         if widget.col1 ~= "alpha" then
             cr:set_source_rgb(gears.color.parse_color(widget.col1))
             cr:new_path()

--- a/widget/alsa.lua
+++ b/widget/alsa.lua
@@ -15,7 +15,7 @@ local string  = string
 -- lain.widget.alsa
 
 local function factory(args)
-    local args     = args or {}
+    args           = args or {}
     local alsa     = { widget = args.widget or wibox.widget.textbox() }
     local timeout  = args.timeout or 5
     local settings = args.settings or function() end

--- a/widget/alsabar.lua
+++ b/widget/alsabar.lua
@@ -30,13 +30,13 @@ local function factory(args)
         _playback      = "off"
     }
 
-    local args       = args or {}
+    args             = args or {}
+
     local timeout    = args.timeout or 5
     local settings   = args.settings or function() end
     local width      = args.width or 63
     local height     = args.height or 1
     local margins    = args.margins or 1
-    local paddings   = args.paddings or 1
     local ticks      = args.ticks or false
     local ticks_size = args.ticks_size or 7
     local tick       = args.tick or "|"
@@ -136,7 +136,7 @@ local function factory(args)
                 end
             end
 
-            int = math.modf((alsabar._current_level / 100) * tot)
+            local int = math.modf((alsabar._current_level / 100) * tot)
             preset.text = string.format(
                 "%s%s%s%s",
                 tick_pre,

--- a/widget/bat.lua
+++ b/widget/bat.lua
@@ -26,7 +26,8 @@ local function factory(args)
         return
     end
 
-    local args        = args or {}
+    args              = args or {}
+
     local bat         = { widget = args.widget or wibox.widget.textbox() }
     local timeout     = args.timeout or 30
     local notify      = args.notify or "on"

--- a/widget/cal.lua
+++ b/widget/cal.lua
@@ -150,7 +150,7 @@ local function factory(args)
 
     function cal.hover_on() cal.show(0) end
     function cal.move(offset)
-        local offset = offset or 0
+        offset = offset or 0
         cal.month, cal.year = cal.getdate(cal.month, cal.year, offset)
         cal.show(0, cal.month, cal.year)
     end

--- a/widget/contrib/moc.lua
+++ b/widget/contrib/moc.lua
@@ -18,7 +18,8 @@ local string       = string
 -- lain.widget.contrib.moc
 
 local function factory(args)
-    local args          = args or {}
+    args                = args or {}
+
     local moc           = { widget = args.widget or wibox.widget.textbox() }
     local timeout       = args.timeout or 2
     local music_dir     = args.music_dir or os.getenv("HOME") .. "/Music"

--- a/widget/contrib/redshift.lua
+++ b/widget/contrib/redshift.lua
@@ -15,7 +15,7 @@ local type    = type
 -- lain.widget.contrib.redshift
 local redshift = { active = false, pid = nil }
 
-function redshift:start()
+function redshift.start()
     execute("pkill redshift")
     awful.spawn.with_shell("redshift -x") -- clear adjustments
     redshift.pid = awful.spawn.with_shell("redshift")
@@ -25,14 +25,14 @@ function redshift:start()
     end
 end
 
-function redshift:toggle()
+function redshift.toggle()
     async({ awful.util.shell, "-c", string.format("ps -p %d -o pid=", redshift.pid) }, function(f)
         if f and #f > 0 then -- redshift is running
             -- Sending -USR1 toggles redshift (See project website)
             execute("pkill -USR1 redshift")
             redshift.active = not redshift.active
         else -- not started or killed, (re)start it
-            redshift:start()
+            redshift.start()
         end
         redshift.update_fun(redshift.active)
     end)
@@ -43,11 +43,11 @@ end
 -- @param widget:  Widget to attach to.
 -- @param fun:     Function to be run each time redshift is toggled (optional).
 --                 Use it to update widget text or icons on status change.
-function redshift:attach(widget, fun)
+function redshift.attach(widget, fun)
     redshift.update_fun = fun or function() end
-    if not redshift.pid then redshift:start() end
+    if not redshift.pid then redshift.start() end
     if widget then
-        widget:buttons(awful.util.table.join(awful.button({}, 1, function () redshift:toggle() end)))
+        widget:buttons(awful.util.table.join(awful.button({}, 1, function () redshift.toggle() end)))
     end
 end
 

--- a/widget/contrib/task.lua
+++ b/widget/contrib/task.lua
@@ -10,7 +10,6 @@ local markup  = require("lain.util").markup
 local awful   = require("awful")
 local naughty = require("naughty")
 local mouse   = mouse
-local string  = string
 
 -- Taskwarrior notification
 -- lain.widget.contrib.task
@@ -69,7 +68,8 @@ function task.prompt()
 end
 
 function task.attach(widget, args)
-    local args               = args or {}
+    args                     = args or {}
+
     task.show_cmd            = args.show_cmd or "task next"
     task.prompt_text         = args.prompt_text or "Enter task command: "
     task.followtag           = args.followtag or false

--- a/widget/contrib/tp_smapi.lua
+++ b/widget/contrib/tp_smapi.lua
@@ -8,7 +8,6 @@
 
 local helpers = require("lain.helpers")
 local focused = require("awful.screen").focused
-local gears   = require("gears")
 local naughty = require("naughty")
 local wibox   = require("wibox")
 local string  = string
@@ -61,7 +60,7 @@ local function factory(apipath)
         local chem   = tp_smapi.get(batid, "chemistry") or "no_chem"
         local status = tp_smapi.get(batid, "state")
         local time   = tp_smapi.time(batid)
-        local msg    = ""
+        local msg
 
         if status and status ~= "idle" then
             msg = string.format("[%s] %s %s", status, time ~= "N/A" and time or "unknown remaining time",
@@ -80,7 +79,8 @@ local function factory(apipath)
     end
 
     function tp_smapi.create_widget(args)
-        local args      = args or {}
+        args            = args or {}
+
         local pspath    = args.pspath or "/sys/class/power_supply/"
         local batteries = args.batteries or (args.battery and {args.battery}) or {}
         local timeout   = args.timeout or 30
@@ -95,7 +95,7 @@ local function factory(apipath)
 
         local all_batteries_installed = true
 
-        for i, battery in ipairs(batteries) do
+        for _, battery in ipairs(batteries) do
             if not tp_smapi.installed(battery) then
                 naughty.notify {
                     preset = naughty.config.critical,

--- a/widget/cpu.lua
+++ b/widget/cpu.lua
@@ -10,13 +10,13 @@ local helpers  = require("lain.helpers")
 local wibox    = require("wibox")
 local math     = math
 local string   = string
-local tostring = tostring
 
 -- CPU usage
 -- lain.widget.cpu
 
 local function factory(args)
-    local args     = args or {}
+    args           = args or {}
+
     local cpu      = { core = {}, widget = args.widget or wibox.widget.textbox() }
     local timeout  = args.timeout or 2
     local settings = args.settings or function() end

--- a/widget/fs.lua
+++ b/widget/fs.lua
@@ -16,7 +16,6 @@ local math       = math
 local string     = string
 local tconcat    = table.concat
 local type       = type
-local tonumber   = tonumber
 local query_size = Gio.FILE_ATTRIBUTE_FILESYSTEM_SIZE
 local query_free = Gio.FILE_ATTRIBUTE_FILESYSTEM_FREE
 local query_used = Gio.FILE_ATTRIBUTE_FILESYSTEM_USED
@@ -26,7 +25,8 @@ local query      = query_size .. "," .. query_free .. "," .. query_used
 -- lain.widget.fs
 
 local function factory(args)
-    local args      = args or {}
+    args     = args or {}
+
     local fs = {
         widget = args.widget or wibox.widget.textbox(),
         units = {

--- a/widget/imap.lua
+++ b/widget/imap.lua
@@ -17,7 +17,8 @@ local tonumber = tonumber
 -- lain.widget.imap
 
 local function factory(args)
-    local args       = args or {}
+    args             = args or {}
+
     local imap       = { widget = args.widget or wibox.widget.textbox() }
     local server     = args.server
     local mail       = args.mail

--- a/widget/mem.lua
+++ b/widget/mem.lua
@@ -14,7 +14,8 @@ local gmatch, lines, floor = string.gmatch, io.lines, math.floor
 -- lain.widget.mem
 
 local function factory(args)
-    local args     = args or {}
+    args           = args or {}
+
     local mem      = { widget = args.widget or wibox.widget.textbox() }
     local timeout  = args.timeout or 2
     local settings = args.settings or function() end

--- a/widget/mpd.lua
+++ b/widget/mpd.lua
@@ -19,7 +19,8 @@ local string   = string
 -- lain.widget.mpd
 
 local function factory(args)
-    local args          = args or {}
+    args                = args or {}
+
     local mpd           = { widget = args.widget or wibox.widget.textbox() }
     local timeout       = args.timeout or 2
     local password      = (args.password and #args.password > 0 and string.format("password %s\\n", args.password)) or ""

--- a/widget/net.lua
+++ b/widget/net.lua
@@ -15,7 +15,8 @@ local string  = string
 -- lain.widget.net
 
 local function factory(args)
-    local args       = args or {}
+    args             = args or {}
+
     local net        = { widget = args.widget or wibox.widget.textbox(), devices = {} }
     local timeout    = args.timeout or 2
     local units      = args.units or 1024 -- KB
@@ -70,16 +71,16 @@ local function factory(args)
 
             if wifi_state == "on" and helpers.first_line(string.format("/sys/class/net/%s/uevent", dev)) == "DEVTYPE=wlan" then
                 dev_now.wifi   = true
-								if string.match(dev_now.carrier, "1") then
-	              		dev_now.signal = tonumber(string.match(helpers.lines_from("/proc/net/wireless")[3], "(%-%d+%.)")) or nil
-								end
-						else
+                if string.match(dev_now.carrier, "1") then
+                        dev_now.signal = tonumber(string.match(helpers.lines_from("/proc/net/wireless")[3], "(%-%d+%.)")) or nil
+                end
+            else
                 dev_now.wifi   = false
             end
 
             if eth_state == "on" and helpers.first_line(string.format("/sys/class/net/%s/uevent", dev)) ~= "DEVTYPE=wlan" then
                 dev_now.ethernet = true
-						else
+            else
                 dev_now.ethernet = false
             end
 

--- a/widget/pulse.lua
+++ b/widget/pulse.lua
@@ -15,7 +15,8 @@ local type    = type
 -- lain.widget.pulse
 
 local function factory(args)
-    local args     = args or {}
+    args           = args or {}
+
     local pulse    = { widget = args.widget or wibox.widget.textbox(), device = "N/A" }
     local timeout  = args.timeout or 5
     local settings = args.settings or function() end

--- a/widget/pulsebar.lua
+++ b/widget/pulsebar.lua
@@ -32,7 +32,8 @@ local function factory(args)
         device         = "N/A"
     }
 
-    local args       = args or {}
+    args             = args or {}
+
     local timeout    = args.timeout or 5
     local settings   = args.settings or function() end
     local width      = args.width or 63
@@ -144,7 +145,7 @@ local function factory(args)
                 end
             end
 
-            int = math.modf((pulsebar._current_level / 100) * tot)
+            local int = math.modf((pulsebar._current_level / 100) * tot)
             preset.text = string.format(
                 "%s%s%s%s",
                 tick_pre,

--- a/widget/sysload.lua
+++ b/widget/sysload.lua
@@ -14,7 +14,8 @@ local open, match = io.open, string.match
 -- lain.widget.sysload
 
 local function factory(args)
-    local args     = args or {}
+    args           = args or {}
+
     local sysload  = { widget = args.widget or wibox.widget.textbox() }
     local timeout  = args.timeout or 2
     local settings = args.settings or function() end

--- a/widget/temp.lua
+++ b/widget/temp.lua
@@ -13,7 +13,8 @@ local tonumber = tonumber
 -- lain.widget.temp
 
 local function factory(args)
-    local args     = args or {}
+    args           = args or {}
+
     local temp     = { widget = args.widget or wibox.widget.textbox() }
     local timeout  = args.timeout or 30
     local tempfile = args.tempfile or "/sys/devices/virtual/thermal/thermal_zone0/temp"

--- a/widget/weather.lua
+++ b/widget/weather.lua
@@ -21,18 +21,17 @@ local tonumber = tonumber
 -- lain.widget.weather
 
 local function factory(args)
-    local args                  = args or {}
+    args                        = args or {}
+
     local weather               = { widget = args.widget or wibox.widget.textbox() }
     local APPID                 = args.APPID or "3e321f9414eaedbfab34983bda77a66e" -- lain's default
     local timeout               = args.timeout or 60 * 15 -- 15 min
-    local timeout_forecast      = args.timeout or 60 * 60 * 24 -- 24 hrs
     local current_call          = args.current_call  or "curl -s 'https://api.openweathermap.org/data/2.5/weather?id=%s&units=%s&lang=%s&APPID=%s'"
     local forecast_call         = args.forecast_call or "curl -s 'https://api.openweathermap.org/data/2.5/forecast/daily?id=%s&units=%s&lang=%s&cnt=%s&APPID=%s'"
     local city_id               = args.city_id or 0 -- placeholder
     local units                 = args.units or "metric"
     local lang                  = args.lang or "en"
     local cnt                   = args.cnt or 5
-    local date_cmd              = args.date_cmd or "date -u -d @%d +'%%a %%d'"
     local icons_path            = args.icons_path or helpers.icons_dir .. "openweathermap/"
     local notification_preset   = args.notification_preset or {}
     local notification_text_fun = args.notification_text_fun or
@@ -91,8 +90,8 @@ local function factory(args)
     function weather.forecast_update()
         local cmd = string.format(forecast_call, city_id, units, lang, cnt, APPID)
         helpers.async(cmd, function(f)
-            local pos, err
-            weather_now, pos, err = json.decode(f, 1, nil)
+            local err
+            weather_now, _, err = json.decode(f, 1, nil)
 
             if not err and type(weather_now) == "table" and tonumber(weather_now["cod"]) == 200 then
                 weather.notification_text = ""
@@ -110,8 +109,8 @@ local function factory(args)
     function weather.update()
         local cmd = string.format(current_call, city_id, units, lang, APPID)
         helpers.async(cmd, function(f)
-            local pos, err, icon
-            weather_now, pos, err = json.decode(f, 1, nil)
+            local err
+            weather_now, _, err = json.decode(f, 1, nil)
 
             if not err and type(weather_now) == "table" and tonumber(weather_now["cod"]) == 200 then
                 local sunrise = tonumber(weather_now["sys"]["sunrise"])


### PR DESCRIPTION
Using _"luacheck . --ignore={111,112,113,631}"_ this reduces warning count from 81 to 9

Ignored warnings:
* 111 - Setting an undefined global variable.
* 112 - Mutating an undefined global variable.
* 113 - Accessing an undefined global variable.
* 631 - Line is too long.

 [Full list of warnings](https://luacheck.readthedocs.io/en/stable/warnings.html)