### PR TITLE
Remove use of global variables in widget/{alsabar,cpu,mem}.lua

### DIFF
--- a/widget/alsabar.lua
+++ b/widget/alsabar.lua
@@ -95,11 +95,6 @@ local function factory(args)
                     alsabar.bar.color = alsabar.colors.unmute
                 end
 
-                volume_now = {
-                    level  = alsabar._current_level,
-                    status = alsabar._playback
-                }
-
                 settings()
 
                 if type(callback) == "function" then callback() end

--- a/widget/cpu.lua
+++ b/widget/cpu.lua
@@ -18,8 +18,9 @@ local function factory(args)
     args           = args or {}
 
     local cpu      = { core = {}, widget = args.widget or wibox.widget.textbox() }
-    local timeout  = args.timeout or 2
-    local settings = args.settings or function() end
+
+    cpu.timeout  = args.timeout or 2
+    cpu.settings = args.settings or function() end
 
     function cpu.update()
         -- Read the amount of time the CPUs have spent performing
@@ -64,10 +65,10 @@ local function factory(args)
         cpu_now.usage = cpu_now[0].usage
         widget = cpu.widget
 
-        settings()
+        cpu.settings()
     end
 
-    helpers.newtimer("cpu", timeout, cpu.update)
+    helpers.newtimer("cpu", cpu.timeout, cpu.update)
 
     return cpu
 end

--- a/widget/cpu.lua
+++ b/widget/cpu.lua
@@ -61,10 +61,6 @@ local function factory(args)
             end
         end
 
-        cpu_now = cpu.core
-        cpu_now.usage = cpu_now[0].usage
-        widget = cpu.widget
-
         cpu.settings()
     end
 

--- a/widget/cpu.lua
+++ b/widget/cpu.lua
@@ -6,10 +6,10 @@
 
 --]]
 
-local helpers  = require("lain.helpers")
-local wibox    = require("wibox")
 local math     = math
 local string   = string
+local wibox    = require("wibox")
+local helpers  = require("lain.helpers")
 
 -- CPU usage
 -- lain.widget.cpu
@@ -19,20 +19,21 @@ local function factory(args)
 
     local cpu      = { core = {}, widget = args.widget or wibox.widget.textbox() }
 
-    cpu.timeout  = args.timeout or 2
     cpu.settings = args.settings or function() end
+    cpu.timeout  = args.timeout or 2
 
     function cpu.update()
         -- Read the amount of time the CPUs have spent performing
         -- different kinds of work. Read the first line of /proc/stat
         -- which is the sum of all CPUs.
-        for index,time in pairs(helpers.lines_match("cpu","/proc/stat")) do
-            local coreid = index - 1
-            local core   = cpu.core[coreid] or
-                           { last_active = 0 , last_total = 0, usage = 0 }
+        for index, time in pairs(helpers.lines_match("cpu","/proc/stat")) do
             local at     = 1
+            local coreid = index - 1
             local idle   = 0
             local total  = 0
+
+            local core   = cpu.core[coreid] or
+                           { last_active = 0 , last_total = 0, usage = 0 }
 
             for field in string.gmatch(time, "[%s]+([^%s]+)") do
                 -- 4 = idle, 5 = ioWait. Essentially, the CPUs have done
@@ -40,8 +41,8 @@ local function factory(args)
                 if at == 4 or at == 5 then
                     idle = idle + field
                 end
-                total = total + field
                 at = at + 1
+                total = total + field
             end
 
             local active = total - idle

--- a/widget/mem.lua
+++ b/widget/mem.lua
@@ -40,7 +40,6 @@ local function factory(args)
         mem_now.swapused = mem_now.swap - mem_now.swapf
         mem_now.perc = math.floor(mem_now.used / mem_now.total * 100)
 
-        widget = mem.widget
         mem.settings()
     end
 

--- a/widget/mem.lua
+++ b/widget/mem.lua
@@ -5,10 +5,9 @@
       * (c) 2010-2012, Peter Hofmann
 
 --]]
-
-local helpers              = require("lain.helpers")
-local wibox                = require("wibox")
 local gmatch, lines, floor = string.gmatch, io.lines, math.floor
+local wibox                = require("wibox")
+local helpers              = require("lain.helpers")
 
 -- Memory usage (ignoring caches)
 -- lain.widget.mem
@@ -18,25 +17,26 @@ local function factory(args)
 
     local mem      = { widget = args.widget or wibox.widget.textbox() }
 
-    mem.timeout    = args.timeout or 2
     mem.settings   = args.settings or function() end
+    mem.timeout    = args.timeout or 2
 
     function mem.update()
         for line in lines("/proc/meminfo") do
             for k, v in gmatch(line, "([%a]+):[%s]+([%d]+).+") do
-                if     k == "MemTotal"     then mem.total = floor(v / 1024 + 0.5)
-                elseif k == "MemFree"      then mem.free  = floor(v / 1024 + 0.5)
-                elseif k == "Buffers"      then mem.buf   = floor(v / 1024 + 0.5)
+                if k == "Buffers"      then mem.buf   = floor(v / 1024 + 0.5)
                 elseif k == "Cached"       then mem.cache = floor(v / 1024 + 0.5)
-                elseif k == "SwapTotal"    then mem.swap  = floor(v / 1024 + 0.5)
-                elseif k == "SwapFree"     then mem.swapf = floor(v / 1024 + 0.5)
+                elseif k == "MemFree"      then mem.free  = floor(v / 1024 + 0.5)
+                elseif k == "MemTotal"     then mem.total = floor(v / 1024 + 0.5)
                 elseif k == "SReclaimable" then mem.srec  = floor(v / 1024 + 0.5)
+                elseif k == "SwapFree"     then mem.swapf = floor(v / 1024 + 0.5)
+                elseif k == "SwapTotal"    then mem.swap  = floor(v / 1024 + 0.5)
                 end
             end
         end
 
-        mem.used = mem.total - mem.free - mem.buf - mem.cache - mem.srec
         mem.swapused = mem.swap - mem.swapf
+        mem.used = mem.total - mem.free - mem.buf - mem.cache - mem.srec
+
         mem.perc = math.floor(mem.used / mem.total * 100)
 
         mem.settings()

--- a/widget/mem.lua
+++ b/widget/mem.lua
@@ -17,8 +17,9 @@ local function factory(args)
     args           = args or {}
 
     local mem      = { widget = args.widget or wibox.widget.textbox() }
-    local timeout  = args.timeout or 2
-    local settings = args.settings or function() end
+
+    mem.timeout    = args.timeout or 2
+    mem.settings   = args.settings or function() end
 
     function mem.update()
         mem_now = {}
@@ -40,10 +41,10 @@ local function factory(args)
         mem_now.perc = math.floor(mem_now.used / mem_now.total * 100)
 
         widget = mem.widget
-        settings()
+        mem.settings()
     end
 
-    helpers.newtimer("mem", timeout, mem.update)
+    helpers.newtimer("mem", mem.timeout, mem.update)
 
     return mem
 end

--- a/widget/mem.lua
+++ b/widget/mem.lua
@@ -22,23 +22,22 @@ local function factory(args)
     mem.settings   = args.settings or function() end
 
     function mem.update()
-        mem_now = {}
         for line in lines("/proc/meminfo") do
             for k, v in gmatch(line, "([%a]+):[%s]+([%d]+).+") do
-                if     k == "MemTotal"     then mem_now.total = floor(v / 1024 + 0.5)
-                elseif k == "MemFree"      then mem_now.free  = floor(v / 1024 + 0.5)
-                elseif k == "Buffers"      then mem_now.buf   = floor(v / 1024 + 0.5)
-                elseif k == "Cached"       then mem_now.cache = floor(v / 1024 + 0.5)
-                elseif k == "SwapTotal"    then mem_now.swap  = floor(v / 1024 + 0.5)
-                elseif k == "SwapFree"     then mem_now.swapf = floor(v / 1024 + 0.5)
-                elseif k == "SReclaimable" then mem_now.srec  = floor(v / 1024 + 0.5)
+                if     k == "MemTotal"     then mem.total = floor(v / 1024 + 0.5)
+                elseif k == "MemFree"      then mem.free  = floor(v / 1024 + 0.5)
+                elseif k == "Buffers"      then mem.buf   = floor(v / 1024 + 0.5)
+                elseif k == "Cached"       then mem.cache = floor(v / 1024 + 0.5)
+                elseif k == "SwapTotal"    then mem.swap  = floor(v / 1024 + 0.5)
+                elseif k == "SwapFree"     then mem.swapf = floor(v / 1024 + 0.5)
+                elseif k == "SReclaimable" then mem.srec  = floor(v / 1024 + 0.5)
                 end
             end
         end
 
-        mem_now.used = mem_now.total - mem_now.free - mem_now.buf - mem_now.cache - mem_now.srec
-        mem_now.swapused = mem_now.swap - mem_now.swapf
-        mem_now.perc = math.floor(mem_now.used / mem_now.total * 100)
+        mem.used = mem.total - mem.free - mem.buf - mem.cache - mem.srec
+        mem.swapused = mem.swap - mem.swapf
+        mem.perc = math.floor(mem.used / mem.total * 100)
 
         mem.settings()
     end


### PR DESCRIPTION
This is bad, instead we should pass the data as arguments to `settings` function. I have no motivation to refactor every single widget, but you can see the way I would do it here: 8aabc07d654ca929a67442eb79e624b7a584ef80.


*Old text:*
#### This introduces a new way of changing 'settings()' function of `cpu` and `mem` widgets:
Instead of setting mem's `settings()` function like this: 
```
local cpu = lain.widget.cpu({
       settings = function()
               widget:set_markup(string.format("%s%%", cpu_now.usage))
       end,
})
```
Following can be used:
```
local widget_ram = lain.widget.mem()

widget_ram.settings = function()
	widget_ram.widget:set_markup(string.format("%s MB (%s%%)", widget_ram.used, widget_ram.perc))
end
```
*Edit: this can be made even better by passing these members as arguments to settings() function.*
In fact, this is required now, as the global variables in the first example are no longer defined
`timeout` is now also a member but it can't be changed like this because it's used outside of `update` function.
TODO: things like `timeout` should not be members. References to members available in the `settings` function should be it's arguments.

#### This would also require following changes to wiki:
To **alsabar:**
In the table after `settings can use the following variables:`:
Replace `volume_now.level` with `volume._current_level` 
Replace `volume_now.status` with `volume._playback`

To **mem**:
Replace `mem_now` occurrences with `mymem`

To **cpu**:
Replace `cpu_now.usage` with `cpu.core[0].usage`
Replace `cpu_now` occurrences with `cpu.core`

To both **mem** and **cpu**:
Indicate that `settings` and `timeout` are now available as instance variables

To the **index page of "widgets" section**:
Change the example to this:
```
local cpu = lain.widget.cpu()
cpu.settings = function()
    widget:set_markup("CPU " .. cpu.core[0].usage)
end
```

#### Additional note
Maybe I missed something and something else has to be changed as well.
The changes are breaking, but global variables should not be used, and this can be the first step to get rid of them.
There are also comments under commits, maybe they are worth checking out. Commit messages could be too long, tell me if it matters.