### PR TITLE
Validate function before callback. Fixes #482.

### DIFF
--- a/widget/fs.lua
+++ b/widget/fs.lua
@@ -137,7 +137,7 @@ local function factory(args)
     function fs.update(callback)
         Gio.Async.start(gears.protected_call.call)(function()
             update_synced()
-            if callback then
+            if type(callback) == "function" and callback then
                 callback()
             end
         end)


### PR DESCRIPTION
As I described in #482, a type check is missing (present in 2 other widgets), resulting in callback being called even when not a function.