### PR TITLE
Fix ac detection for bat widget.

### DIFF
--- a/widget/bat.lua
+++ b/widget/bat.lua
@@ -43,7 +43,7 @@ local function factory(args)
             if bstr then
                 batteries[#batteries + 1] = bstr
             else
-                ac = string.match(line, "A%w+") or "AC0"
+                ac = string.match(line, "A%w+") or ac
             end
         end)
     end


### PR DESCRIPTION
Multiple power sources may exist under /sys/class/power_supply/.
Durring autodetection (get_batteries), will case the detected ac to be reset to 'AC0' if a power source not starting with BAT or AC.

This change skips updating the name of the ac device if the devices does not start with 'AC'