### PR TITLE
Fix for openweathermap.org API changes

### DIFF
--- a/widget/weather.lua
+++ b/widget/weather.lua
@@ -27,7 +27,7 @@ local function factory(args)
     local APPID                 = args.APPID or "3e321f9414eaedbfab34983bda77a66e" -- lain's default
     local timeout               = args.timeout or 60 * 15 -- 15 min
     local current_call          = args.current_call  or "curl -s 'https://api.openweathermap.org/data/2.5/weather?id=%s&units=%s&lang=%s&APPID=%s'"
-    local forecast_call         = args.forecast_call or "curl -s 'https://api.openweathermap.org/data/2.5/forecast/daily?id=%s&units=%s&lang=%s&cnt=%s&APPID=%s'"
+    local forecast_call         = args.forecast_call or "curl -s 'https://api.openweathermap.org/data/2.5/forecast?id=%s&units=%s&lang=%s&APPID=%s'"
     local city_id               = args.city_id or 0 -- placeholder
     local units                 = args.units or "metric"
     local lang                  = args.lang or "en"
@@ -37,8 +37,8 @@ local function factory(args)
     local notification_text_fun = args.notification_text_fun or
                                   function (wn)
                                       local day = os.date("%a %d", wn["dt"])
-                                      local tmin = math.floor(wn["temp"]["min"])
-                                      local tmax = math.floor(wn["temp"]["max"])
+                                      local tmin = math.floor(wn["main"]["temp_min"])
+                                      local tmax = math.floor(wn["main"]["temp_max"])
                                       local desc = wn["weather"][1]["description"]
                                       return string.format("<b>%s</b>: %s, %d - %d ", day, desc, tmin, tmax)
                                   end
@@ -88,14 +88,14 @@ local function factory(args)
     end
 
     function weather.forecast_update()
-        local cmd = string.format(forecast_call, city_id, units, lang, cnt, APPID)
+        local cmd = string.format(forecast_call, city_id, units, lang, APPID)
         helpers.async(cmd, function(f)
             local err
             weather_now, _, err = json.decode(f, 1, nil)
 
             if not err and type(weather_now) == "table" and tonumber(weather_now["cod"]) == 200 then
                 weather.notification_text = ""
-                for i = 1, weather_now["cnt"] do
+                for i = 1, weather_now["cnt"], weather_now["cnt"]//cnt do
                     weather.notification_text = weather.notification_text ..
                                                 notification_text_fun(weather_now["list"][i])
                     if i < weather_now["cnt"] then


### PR DESCRIPTION
I've spotted today that weather forecast widget constantly shows N/A. After some investigations it appears that API key included into lain is blocked. Also it appears that API usage terms are changed, also some minor changes in API syntax were introduced.
Here is patch proposed for making it work again.
As old key doesn't working, you have to sign up at https://openweathermap.org/ and obtain your personal API key. Then assign it's value to variable APPID in rc.lua, e.g.:
```lua
    myweather = lain.widget.weather({
      APPID="7a2cdcc0814811eb8dcd0242ac130003",
      cnt=8,
      city_id=2179537,
      units="metric",
      settings = function()
        units = math.floor(weather_now["main"]["temp"])
        widget:set_markup(markup("#008050", " " .. units .. "°C "))
      end,
      notification_text_fun = function(wn)
        local  day = os.date("%a %d %H:%M", wn["dt"])
        local desc = wn["weather"][1]["description"]
        local tmin = math.floor(wn["main"]["temp_min"])   -- min daily
        local tmax = math.floor(wn["main"]["temp_max"])   -- max daily
        local tfeel= math.floor(wn["main"]["feels_like"])   -- feels like...
        local pres = math.floor(wn["main"]["pressure"])
        local humi = math.floor(wn["main"]["humidity"])
        local wspe = math.floor(wn["wind"]["speed"])
        local wdeg = math.floor(wn["wind"]["deg"])
        local clou = math.floor(wn["clouds"]["all"])
        return string.format("<br><b>%s</b>: %s<br>T: %d - %d °C, FL: %d °C<br>P: %d hPa, H: %d%%<br>Wind: %d m/s at %d°<br>Cloudiness: %d%%", day, desc, tmin, tmax, tfeel, pres, humi, wspe, wdeg, clou)
        end,
    })
```