### PR TITLE
Adding ALSA widget press callback function in args

### DIFF
--- a/widget/alsa.lua
+++ b/widget/alsa.lua
@@ -23,6 +23,8 @@ local function factory(args)
     alsa.cmd           = args.cmd or "amixer"
     alsa.channel       = args.channel or "Master"
     alsa.togglechannel = args.togglechannel
+    alsa.pressed       = args.pressed or function(button) end
+
 
     local format_cmd = string.format("%s get %s", alsa.cmd, alsa.channel)
 
@@ -44,6 +46,10 @@ local function factory(args)
             end
         end)
     end
+
+    alsa.widget:connect_signal("button::press", function(c, _, _, button)
+       alsa.pressed(button)
+    end)
 
     helpers.newtimer(string.format("alsa-%s-%s", alsa.cmd, alsa.channel), timeout, alsa.update)
 

--- a/widget/weather.lua
+++ b/widget/weather.lua
@@ -24,7 +24,7 @@ local function factory(args)
     args                        = args or {}
 
     local weather               = { widget = args.widget or wibox.widget.textbox() }
-    local APPID                 = args.APPID or "3e321f9414eaedbfab34983bda77a66e" -- lain's default
+    local APPID                 = args.APPID -- mandatory
     local timeout               = args.timeout or 60 * 15 -- 15 min
     local current_call          = args.current_call  or "curl -s 'https://api.openweathermap.org/data/2.5/weather?id=%s&units=%s&lang=%s&APPID=%s'"
     local forecast_call         = args.forecast_call or "curl -s 'https://api.openweathermap.org/data/2.5/forecast?id=%s&units=%s&lang=%s&APPID=%s'"


### PR DESCRIPTION
This way we can specify a widget press callback function in `rc.lua` or `theme.lua`.
I use this to open `pavucontrol`.

```lua
theme.lua
--------------------------------------------------------------------------------------------------------------------
theme.volume = lain.widget.alsa({
    settings = function()
        if volume_now.status == "off" then
            volicon:set_image(theme.volmutedblocked)
        elseif volume_now.level == 0 then
            volicon:set_image(theme.volmuted)
        elseif volume_now.level <= 5 then
            volicon:set_image(theme.voloff)
        elseif volume_now.level <= 25 then
            volicon:set_image(theme.vollow)
        elseif volume_now.level <= 75 then
            volicon:set_image(theme.volmed)
        else
            volicon:set_image(theme.volhigh)
        end

        widget:set_markup(markup.font(theme.font, " " .. volume_now.level .. "% "))
    end
})
```

```lua
rc.lua
--------------------------------------------------------------------------------------------------------------------
-- voulme/alsa widget pressed callback function - start pavucontrol application
beautiful.volume.pressed = function(button)
    if button == 1 then  -- left mouse click
        awful.spawn.with_shell("pavucontrol")
    end
end
```