### PR TITLE
Prevent re-drawing cal notification after change

### DIFF
--- a/widget/cal.lua
+++ b/widget/cal.lua
@@ -138,7 +138,11 @@ local function factory(args)
             cal.month, cal.year = current_month, current_year
         end
 
-        cal.hide()
+        if cal.notification then
+            naughty.replace_text(cal.notification, nil, text)
+            return
+        end
+        
         cal.notification = naughty.notify {
             preset  = cal.notification_preset,
             screen  = cal.followtag and awful.screen.focused() or scr or 1,

--- a/widget/cal.lua
+++ b/widget/cal.lua
@@ -139,10 +139,11 @@ local function factory(args)
         end
 
         if cal.notification then
-            naughty.replace_text(cal.notification, nil, text)
+            local title = cal.notification_preset.title or nil
+            naughty.replace_text(cal.notification, title, text)
             return
         end
-        
+
         cal.notification = naughty.notify {
             preset  = cal.notification_preset,
             screen  = cal.followtag and awful.screen.focused() or scr or 1,

--- a/widget/weather.lua
+++ b/widget/weather.lua
@@ -24,7 +24,7 @@ local function factory(args)
     args                        = args or {}
 
     local weather               = { widget = args.widget or wibox.widget.textbox() }
-    local APPID                 = args.APPID or "3e321f9414eaedbfab34983bda77a66e" -- lain's default
+    local APPID                 = args.APPID -- mandatory
     local timeout               = args.timeout or 60 * 15 -- 15 min
     local current_call          = args.current_call  or "curl -s 'https://api.openweathermap.org/data/2.5/weather?id=%s&units=%s&lang=%s&APPID=%s'"
     local forecast_call         = args.forecast_call or "curl -s 'https://api.openweathermap.org/data/2.5/forecast?id=%s&units=%s&lang=%s&APPID=%s'"


### PR DESCRIPTION
Calling hide() on notification causes split-second flash of the widget. This change allows direct replacement of its content, without container flashes.