### PR TITLE
Fix issue #499

### DIFF
--- a/widget/weather.lua
+++ b/widget/weather.lua
@@ -37,10 +37,9 @@ local function factory(args)
     local notification_text_fun = args.notification_text_fun or
                                   function (wn)
                                       local day = os.date("%a %d", wn["dt"])
-                                      local tmin = math.floor(wn["main"]["temp_min"])
-                                      local tmax = math.floor(wn["main"]["temp_max"])
+                                      local temp = math.floor(wn["main"]["temp"])
                                       local desc = wn["weather"][1]["description"]
-                                      return string.format("<b>%s</b>: %s, %d - %d ", day, desc, tmin, tmax)
+                                      return string.format("<b>%s</b>: %s, %d ", day, desc, temp)
                                   end
     local weather_na_markup     = args.weather_na_markup or " N/A "
     local followtag             = args.followtag or false


### PR DESCRIPTION
As @cyberpunkrocker-zero mentioned in #499,

> "temp_min" and "temp_max" both show always the same value, which is equal to "temp". They are not real min/max temperatures any more. For the current Openweathermap situation the forecast notification popup should be modified so that it shows only the value of "temp"

Proposed PR removes ```temp_min``` and ```temp_max``` and uses ```temp``` instead