### PR TITLE
Fix alsa widget updating unnecessarily

### DIFF
--- a/widget/alsa.lua
+++ b/widget/alsa.lua
@@ -36,8 +36,9 @@ local function factory(args)
     function alsa.update()
         helpers.async(format_cmd, function(mixer)
             local l,s = string.match(mixer, "([%d]+)%%.*%[([%l]*)")
+            l = tonumber(l)
             if alsa.last.level ~= l or alsa.last.status ~= s then
-                volume_now = { level = tonumber(l), status = s }
+                volume_now = { level = l, status = s }
                 widget = alsa.widget
                 settings()
                 alsa.last = volume_now


### PR DESCRIPTION
The comparison `alsa.last.level ~= l` always returned true. Fixed by converting to number before comparison.