### PR TITLE
Add format option for net and temp widget

### DIFF
--- a/widget/net.lua
+++ b/widget/net.lua
@@ -24,6 +24,7 @@ local function factory(args)
     local wifi_state = args.wifi_state or "off"
     local eth_state  = args.eth_state or "off"
     local screen     = args.screen or 1
+    local format     = args.format or "%.1f"
     local settings   = args.settings or function() end
 
     -- Compatibility with old API where iface was a string corresponding to 1 interface
@@ -63,8 +64,8 @@ local function factory(args)
             net_now.sent     = net_now.sent + dev_now.sent
             net_now.received = net_now.received + dev_now.received
 
-            dev_now.sent     = string.format("%.1f", dev_now.sent)
-            dev_now.received = string.format("%.1f", dev_now.received)
+            dev_now.sent     = string.format(format, dev_now.sent)
+            dev_now.received = string.format(format, dev_now.received)
 
             dev_now.last_t   = now_t
             dev_now.last_r   = now_r
@@ -106,8 +107,8 @@ local function factory(args)
             -- the totals across all specified devices
         end
 
-        net_now.sent = string.format("%.1f", net_now.sent)
-        net_now.received = string.format("%.1f", net_now.received)
+        net_now.sent = string.format(format, net_now.sent)
+        net_now.received = string.format(format, net_now.received)
 
         widget = net.widget
         settings()

--- a/widget/temp.lua
+++ b/widget/temp.lua
@@ -18,6 +18,7 @@ local function factory(args)
     local temp     = { widget = args.widget or wibox.widget.textbox() }
     local timeout  = args.timeout or 30
     local tempfile = args.tempfile or "/sys/devices/virtual/thermal/thermal_zone0/temp"
+    local format   = args.format or "%.1f"
     local settings = args.settings or function() end
 
     function temp.update()
@@ -31,7 +32,7 @@ local function factory(args)
                     temp_now[t] = temp_value and temp_value/1e3 or temp_fl
                 end
             end
-            coretemp_now = temp_now[tempfile] or "N/A"
+            coretemp_now = string.format(format, temp_now[tempfile]) or "N/A"
             widget = temp.widget
             settings()
         end)


### PR DESCRIPTION
This lets the user specify format for the string in the net and temp widget. For example to change the number of decimals.

I did not understand how to add to the wiki (do I fork the wiki somehow?). I was thinking adding this line (to both widgets) would be enough:
```
`format` | String format for output | string | "%.1f"
```