### PR TITLE
Fix rockspec

### DIFF
--- a/lain-scm-1.rockspec
+++ b/lain-scm-1.rockspec
@@ -1,8 +1,8 @@
 package = "lain"
 version = "scm-1"
 source = {
-   url = "https://github.com/lcpz/lain",
-   tag = "scm-1`"
+   url = "git+https://github.com/lcpz/lain.git",
+   tag = "master"
 }
 description = {
    summary = "Layout, widgets and utilities for Awesome WM",
@@ -15,13 +15,11 @@ description = {
    license = "GPL-2.0"
 }
 dependencies = {
-   "lua >= 5.1",
-   "awesome >= 4.0",
-   "Glib >= 2.54",
-   "curl"
+   "lua >= 5.1"
 }
 supported_platforms = { "linux" }
 build = {
    type = "builtin",
    modules = { lain = "init.lua" }
 }
+


### PR DESCRIPTION
I could not install lain via luarocks using the existing rockspec file. There were a few issues:

1. There is no `scm-1` tag in the repo,
2. The glib, curl & awesome dependencies do not exist as rocks in the luarocks repo, therefore they should not be dependencies here
3. The format of the repo URL is incorrect, it should be using the `git+https` protocol

Once I fixed those issues I was able to install using a local copy of the rockspec. I'm sure I'm not the first person to install lain via luarocks, how have others have managed to get it to work?