### PR TITLE
Fix temp widget show N/A when no sensor found

### DIFF
--- a/widget/temp.lua
+++ b/widget/temp.lua
@@ -32,7 +32,11 @@ local function factory(args)
                     temp_now[t] = temp_value and temp_value/1e3 or temp_fl
                 end
             end
-            coretemp_now = string.format(format, temp_now[tempfile]) or "N/A"
+            if temp_now[tempfile] then
+                coretemp_now = string.format(format, temp_now[tempfile]) 
+            else
+                coretemp_now = "N/A"
+            end
             widget = temp.widget
             settings()
         end)


### PR DESCRIPTION
Fix so that N/A is shown when no temperature sensor is found. This was broken by my previous commit. Oups.