### PR TITLE
fix(#485): Separators not following theme

### DIFF
--- a/util/separators.lua
+++ b/util/separators.lua
@@ -8,10 +8,11 @@
 
 local wibox = require("wibox")
 local gears = require("gears")
+local beautiful = require("beautiful")
 
 -- Lain Cairo separators util submodule
 -- lain.util.separators
-local separators = { height = 0, width = 9 }
+local separators = { height = (beautiful.separators_height or 0), width = (beautiful.separators_width or 9) }
 
 -- [[ Arrow
 

--- a/util/separators.lua
+++ b/util/separators.lua
@@ -12,7 +12,7 @@ local beautiful = require("beautiful")
 
 -- Lain Cairo separators util submodule
 -- lain.util.separators
-local separators = { height = (beautiful.separators_height or 0), width = (beautiful.separators_width or 9) }
+local separators = { height = beautiful.separators_height or 0, width = beautiful.separators_width or 9 }
 
 -- [[ Arrow
 


### PR DESCRIPTION
Fix issue #485 `lain.util.separators` not following theme variables
separators_width and separators_height as stated in the wiki