### PR TITLE
Fix rockspec modules

### DIFF
--- a/lain-scm-1.rockspec
+++ b/lain-scm-1.rockspec
@@ -17,6 +17,39 @@ dependencies = {
 supported_platforms = { "linux" }
 build = {
    type = "builtin",
-   modules = { lain = "init.lua" }
+   modules = {
+      ["lain"] = "init.lua",
+      ["lain.helpers"] = "helpers.lua",
+      ["lain.layout"] = "layout/init.lua",
+      ["lain.layout.cascade"] = "layout/cascade.lua",
+      ["lain.layout.centerwork"] = "layout/centerwork.lua",
+      ["lain.layout.termfair"] = "layout/termfair.lua",
+      ["lain.util"] = "util/init.lua",
+      -- ["lain.util.dkjson"] = "util/dkjson.lua", -- RESOLVED BY DEPENDENCY TO dkjson
+      ["lain.util.markup"] = "util/markup.lua",
+      ["lain.util.menu_iterator"] = "util/menu_iterator.lua",
+      ["lain.util.quake"] = "util/quake.lua",
+      ["lain.util.separators"] = "util/separators.lua",
+      ["lain.widget"] = "widget/init.lua",
+      ["lain.widget.contrib"] = "widget/contrib/init.lua",
+      ["lain.widget.contrib.moc"] = "widget/contrib/moc.lua",
+      ["lain.widget.contrib.redshift"] = "widget/contrib/redshift.lua",
+      ["lain.widget.contrib.task"] = "widget/contrib/task.lua",
+      ["lain.widget.contrib.tp_smapi"] = "widget/contrib/tp_smapi.lua",
+      ["lain.widget.alsa"] = "widget/alsa.lua",
+      ["lain.widget.alsabar"] = "widget/alsabar.lua",
+      ["lain.widget.bat"] = "widget/bat.lua",
+      ["lain.widget.cal"] = "widget/cal.lua",
+      ["lain.widget.cpu"] = "widget/cpu.lua",
+      ["lain.widget.fs"] = "widget/fs.lua",
+      ["lain.widget.imap"] = "widget/imap.lua",
+      ["lain.widget.mem"] = "widget/mem.lua",
+      ["lain.widget.mpd"] = "widget/mpd.lua",
+      ["lain.widget.net"] = "widget/net.lua",
+      ["lain.widget.pulse"] = "widget/pulse.lua",
+      ["lain.widget.pulsebar"] = "widget/pulsebar.lua",
+      ["lain.widget.sysload"] = "widget/sysload.lua",
+      ["lain.widget.temp"] = "widget/temp.lua",
+      ["lain.widget.weather"] = "widget/weather.lua"
+   }
 }
-


### PR DESCRIPTION
Hello :wave: 

After installing the rock with the command from the wiki https://github.com/lcpz/lain/wiki

```
luarocks install lcpz/lain
```

The installation works successfully, but the installed package is broken.

```
$ lua -lluarocks.loader
Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio
> lain = require "lain"
/home/aireone/.luarocks/share/lua/5.4/lain/init.lua:12: module 'lain.layout' not found:
        No LuaRocks module found for lain.layout
        no field package.preload['lain.layout']
        no file '/usr/share/lua/5.4/lain/layout.lua'
        no file '/usr/share/lua/5.4/lain/layout/init.lua'
        no file '/usr/lib/lua/5.4/lain/layout.lua'
        no file '/usr/lib/lua/5.4/lain/layout/init.lua'
        no file './lain/layout.lua'
        no file './lain/layout/init.lua'
        no file '/home/aireone/.luarocks/share/lua/5.4/lain/layout.lua'
        no file '/home/aireone/.luarocks/share/lua/5.4/lain/layout/init.lua'
        no file '/usr/lib/lua/5.4/lain/layout.so'
        no file '/usr/lib/lua/5.4/loadall.so'
        no file './lain/layout.so'
        no file '/home/aireone/.luarocks/lib/lua/5.4/lain/layout.so'
        no file '/usr/lib/lua/5.4/lain.so'
        no file '/usr/lib/lua/5.4/loadall.so'
        no file './lain.so'
        no file '/home/aireone/.luarocks/lib/lua/5.4/lain.so'
stack traceback:
        [C]: in function 'require'
        /home/aireone/.luarocks/share/lua/5.4/lain/init.lua:12: in main chunk
        [C]: in function 'require'
        stdin:1: in main chunk
        [C]: in ?
```

`/home/aireone/.luarocks/share/lua/5.4/lain/init.lua:12: module 'lain.layout' not found` points to https://github.com/lcpz/lain/blob/master/init.lua#L12

And `ls` in this directory only outputs the `init.lua` file (as expected)

```
$ ls /home/aireone/.luarocks/share/lua/5.4/lain/
init.lua
```

According to https://github.com/luarocks/luarocks/wiki/Creating-a-rock#building-a-module, the `modules = { lain = "init.lua" }` configuration tells Luarocks to install only the `init.lua` file.

This PR fix the `modules` list and make the rockspec file install all the modules (expect `util/dkjson.lua` which is installed by the required dependencies).

It can be tested locally with the installation command (Note to anyone wanting to test that without cloning the repo: you can also use an HTTP URL to the file on GitHub):

```
luarocks --local install lain-scm-1.rockspec
```

After that, the rock can be loaded successfully from an Awesome WM config.

Here is the output `luarocks show lain` gives me. As expected, there is now the full list of modules installed.

```
$ luarocks show lain

lain scm-1 - Layout, widgets and utilities for Awesome WM

Alternative layouts, asynchronous widgets and utility functions for Awesome WM.
Non-Lua dependency: curl (for IMAP, MPD and weather widgets).

License:        GPL2
Homepage:       https://github.com/lcpz/lain
Installed in:   /home/aireone/.luarocks

Modules:
        lain.helpers (/home/aireone/.luarocks/share/lua/5.4/lain/helpers.lua)
        lain.init (/home/aireone/.luarocks/share/lua/5.4/lain/init.lua)
        lain.layout.cascade (/home/aireone/.luarocks/share/lua/5.4/lain/layout/cascade.lua)
        lain.layout.centerwork (/home/aireone/.luarocks/share/lua/5.4/lain/layout/centerwork.lua)
        lain.layout.init (/home/aireone/.luarocks/share/lua/5.4/lain/layout/init.lua)
        lain.layout.termfair (/home/aireone/.luarocks/share/lua/5.4/lain/layout/termfair.lua)
        lain.util.init (/home/aireone/.luarocks/share/lua/5.4/lain/util/init.lua)
        lain.util.markup (/home/aireone/.luarocks/share/lua/5.4/lain/util/markup.lua)
        lain.util.menu_iterator (/home/aireone/.luarocks/share/lua/5.4/lain/util/menu_iterator.lua)
        lain.util.quake (/home/aireone/.luarocks/share/lua/5.4/lain/util/quake.lua)
        lain.util.separators (/home/aireone/.luarocks/share/lua/5.4/lain/util/separators.lua)
        lain.widget.alsa (/home/aireone/.luarocks/share/lua/5.4/lain/widget/alsa.lua)
        lain.widget.alsabar (/home/aireone/.luarocks/share/lua/5.4/lain/widget/alsabar.lua)
        lain.widget.bat (/home/aireone/.luarocks/share/lua/5.4/lain/widget/bat.lua)
        lain.widget.cal (/home/aireone/.luarocks/share/lua/5.4/lain/widget/cal.lua)
        lain.widget.contrib.init (/home/aireone/.luarocks/share/lua/5.4/lain/widget/contrib/init.lua)
        lain.widget.contrib.moc (/home/aireone/.luarocks/share/lua/5.4/lain/widget/contrib/moc.lua)
        lain.widget.contrib.redshift (/home/aireone/.luarocks/share/lua/5.4/lain/widget/contrib/redshift.lua)
        lain.widget.contrib.task (/home/aireone/.luarocks/share/lua/5.4/lain/widget/contrib/task.lua)
        lain.widget.contrib.tp_smapi (/home/aireone/.luarocks/share/lua/5.4/lain/widget/contrib/tp_smapi.lua)
        lain.widget.cpu (/home/aireone/.luarocks/share/lua/5.4/lain/widget/cpu.lua)
        lain.widget.fs (/home/aireone/.luarocks/share/lua/5.4/lain/widget/fs.lua)
        lain.widget.imap (/home/aireone/.luarocks/share/lua/5.4/lain/widget/imap.lua)
        lain.widget.init (/home/aireone/.luarocks/share/lua/5.4/lain/widget/init.lua)
        lain.widget.mem (/home/aireone/.luarocks/share/lua/5.4/lain/widget/mem.lua)
        lain.widget.mpd (/home/aireone/.luarocks/share/lua/5.4/lain/widget/mpd.lua)
        lain.widget.net (/home/aireone/.luarocks/share/lua/5.4/lain/widget/net.lua)
        lain.widget.pulse (/home/aireone/.luarocks/share/lua/5.4/lain/widget/pulse.lua)
        lain.widget.pulsebar (/home/aireone/.luarocks/share/lua/5.4/lain/widget/pulsebar.lua)
        lain.widget.sysload (/home/aireone/.luarocks/share/lua/5.4/lain/widget/sysload.lua)
        lain.widget.temp (/home/aireone/.luarocks/share/lua/5.4/lain/widget/temp.lua)
        lain.widget.weather (/home/aireone/.luarocks/share/lua/5.4/lain/widget/weather.lua)

Depends on:
        lua >= 5.3 (using 5.4-1)
        dkjson >= 2.6-1 (using 2.6-1)

Indirectly pulling:
        dkjson (using 2.6-1)
```